### PR TITLE
fix cumulative monte carlo

### DIFF
--- a/micov/_plot.py
+++ b/micov/_plot.py
@@ -74,7 +74,7 @@ def cumulative_monte(metadata, coverage, positions, target, variable, output,
     target_positions = positions.filter(pl.col(COLUMN_GENOME_ID) == target)
     coverage = coverage.filter(pl.col(COLUMN_GENOME_ID) == target)
     cov_samples = coverage.select(pl.col(COLUMN_SAMPLE_ID).unique())
-    metadata = metadata.filter(pl.col(COLUMN_SAMPLE_ID).is_in(cov_samples))
+    metadata = metadata.filter(pl.col(COLUMN_SAMPLE_ID).is_in(cov_samples[COLUMN_SAMPLE_ID].to_list()))
 
     if len(target_positions) == 0:
         raise ValueError()
@@ -119,7 +119,7 @@ def cumulative_monte(metadata, coverage, positions, target, variable, output,
                                    .shuffle())
                          .head(max_n))
         grp_monte = metadata.filter(pl.col(COLUMN_SAMPLE_ID)
-                                      .is_in(monte))
+                                      .is_in(monte[COLUMN_SAMPLE_ID].to_list()))
         monte_x, cur_y = compute_cumulative(coverage, grp_monte, target,
                                             target_positions, lengths)
         monte_y.append(cur_y)

--- a/micov/_plot.py
+++ b/micov/_plot.py
@@ -74,7 +74,9 @@ def cumulative_monte(metadata, coverage, positions, target, variable, output,
     target_positions = positions.filter(pl.col(COLUMN_GENOME_ID) == target)
     coverage = coverage.filter(pl.col(COLUMN_GENOME_ID) == target)
     cov_samples = coverage.select(pl.col(COLUMN_SAMPLE_ID).unique())
-    metadata = metadata.filter(pl.col(COLUMN_SAMPLE_ID).is_in(cov_samples[COLUMN_SAMPLE_ID].to_list()))
+    metadata = metadata.filter(
+        pl.col(COLUMN_SAMPLE_ID).is_in(
+            cov_samples[COLUMN_SAMPLE_ID].to_list()))
 
     if len(target_positions) == 0:
         raise ValueError()
@@ -118,8 +120,9 @@ def cumulative_monte(metadata, coverage, positions, target, variable, output,
         monte = (metadata.select(pl.col(COLUMN_SAMPLE_ID)
                                    .shuffle())
                          .head(max_n))
-        grp_monte = metadata.filter(pl.col(COLUMN_SAMPLE_ID)
-                                      .is_in(monte[COLUMN_SAMPLE_ID].to_list()))
+        grp_monte = metadata.filter(
+            pl.col(COLUMN_SAMPLE_ID).is_in(
+                monte[COLUMN_SAMPLE_ID].to_list()))
         monte_x, cur_y = compute_cumulative(coverage, grp_monte, target,
                                             target_positions, lengths)
         monte_y.append(cur_y)


### PR DESCRIPTION
This PR is for fixing the following error
```
Traceback (most recent call last):
  File "/home/y1weng/mambaforge/envs/micov_dev3/bin/micov", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/y1weng/mambaforge/envs/micov_dev3/lib/python3.12/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/y1weng/mambaforge/envs/micov_dev3/lib/python3.12/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/y1weng/mambaforge/envs/micov_dev3/lib/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/y1weng/mambaforge/envs/micov_dev3/lib/python3.12/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/y1weng/mambaforge/envs/micov_dev3/lib/python3.12/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/y1weng/34d_micov/micov/micov/cli.py", line 298, in per_sample_monte
    per_sample_plots_monte(all_coverage, all_covered_positions, metadata_pl,
  File "/home/y1weng/34d_micov/micov/micov/_plot.py", line 48, in per_sample_plots_monte
    cumulative_monte(metadata, all_coverage, all_covered_positions, genome,
  File "/home/y1weng/34d_micov/micov/micov/_plot.py", line 77, in cumulative_monte
    metadata = metadata.filter(pl.col(COLUMN_SAMPLE_ID).is_in(cov_samples))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/y1weng/mambaforge/envs/micov_dev3/lib/python3.12/site-packages/polars/dataframe/frame.py", line 5018, in filter
    return self.lazy().filter(*predicates, **constraints).collect(_eager=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/y1weng/mambaforge/envs/micov_dev3/lib/python3.12/site-packages/polars/lazyframe/frame.py", line 2056, in collect
    return wrap_df(ldf.collect(callback))
                   ^^^^^^^^^^^^^^^^^^^^^
polars.exceptions.ComputeError: shapes don't match: expected 5 elements in 'is_in' comparison, got 1
```
when running
```
micov per-sample-monte \
> --parquet-coverage CAuris \
> --sample-metadata ~/46_wastewater_pathogens/md.tsv \
> --sample-metadata-column 'site' \
> --iters 100 \
> --output plot_monte \
> --plot
```

Nothing else is changed. 