### PR TITLE
Implement genome ranking functionality for position plot genomes

### DIFF
--- a/micov/_plot.py
+++ b/micov/_plot.py
@@ -530,6 +530,11 @@ def position_plot(metadata, coverage, positions, target, variable, output,
     value_order = metadata.select(pl.col(variable)
                                     .unique()
                                     .sort())[variable]
+
+    tsv_x = []
+    tsv_y = []
+    tsv_group = []
+
     for name, color in zip(value_order, range(0, 10)):
         grp = metadata.filter(pl.col(variable) == name)
         color = f'C{color}'
@@ -573,6 +578,9 @@ def position_plot(metadata, coverage, positions, target, variable, output,
 
         if scale is not None:
             ax.scatter(hist_x, hist_y, s=.2, color=color, alpha=0.7)
+            tsv_x += hist_x
+            tsv_y += hist_y
+            tsv_group += [name] * len(hist_x)
 
     ax.set_xlim(-0.01, 1.0)
     ax.set_ylim(0, 1.0)
@@ -582,6 +590,16 @@ def position_plot(metadata, coverage, positions, target, variable, output,
         ax.set_ylabel('Unit normalized genome position', fontsize=20)
         scaletag = ""
     else:
+        df = pl.DataFrame({
+                "group": tsv_group,
+                "x": tsv_x,
+                "y": tsv_y
+            })
+        df.write_csv(
+            f"{output}.{target_name}.{target}.{variable}."
+            f"position-plot-1_{scale}th-scale.tsv",
+            separator="\t"
+        )
         ax.set_title(f'Scaled position plot: {target} ({length}bp)', fontsize=20)
         ax.set_ylabel(f'Coverage (1/{scale})th scale', fontsize=20)
         scaletag = f"-1_{scale}th-scale"

--- a/micov/_rank.py
+++ b/micov/_rank.py
@@ -1,0 +1,76 @@
+import pandas as pd
+import numpy as np
+import glob
+from scipy.stats import entropy
+
+
+def gini(array):
+    array = np.sort(array)
+    n = len(array)
+    index = np.arange(1, n + 1)
+    return (np.sum((2 * index - n - 1) * array)) / (n * np.sum(array))
+
+
+def compute_entropy(group):
+    p = group.value_counts(normalize=True)
+    return entropy(p, base=2)
+
+
+def rank_sample_groups(group_df):
+    # entropy lower, distribution more variable
+    entropy_rank = group_df["entropy"].rank(ascending=True)
+    # gini higher, distribution more variable
+    gini_rank = group_df["gini"].rank(ascending=False)
+    # CV higher, distribution more variable
+    cv_rank = group_df["cv"].rank(ascending=False)
+
+    group_df["ranking"] = (entropy_rank + gini_rank + cv_rank).rank(
+        method="dense", ascending=True) # tie wil be given the same rank
+
+    return group_df
+
+
+def choose_most_variable_group(group_df):
+    group_df = rank_sample_groups(group_df)
+    best_group = group_df["ranking"].idxmin()
+    return group_df.loc[[best_group]]
+
+
+def rank_genome_of_interest(plotdir):
+    all_files = glob.glob(f"{plotdir}/*.tsv")
+    metrics_selected = []
+
+    for file in all_files:
+        df = pd.read_csv(file, sep="\t")
+
+        # Compute variability metrics for each group in this file
+        y_distribution = df.groupby(["group", "y"])["x"].count().reset_index()
+        y_distribution.rename(columns={"x": "count_x"}, inplace=True)
+
+        # Compute all metrics per group
+        metrics = y_distribution.groupby("group")["count_x"].agg(
+            mean="mean",
+            std="std",
+            entropy=compute_entropy,
+            gini=gini
+        ).assign(cv=lambda x: x["std"] / x["mean"])
+
+        selected_group = choose_most_variable_group(metrics)
+        selected_group["filename"] = file.split('/')[-1]
+        metrics_selected.append(selected_group)
+
+    metrics_df = pd.concat(metrics_selected)
+
+    genomes_ranked = rank_sample_groups(metrics_df).sort_values('ranking')
+
+    genomes_ranked = (
+        genomes_ranked
+        .reset_index()
+        .rename(columns={"index": "group"})
+    )
+    column_order = ["filename", "group"] + [
+        col for col in genomes_ranked.columns if col not in ["filename", "group"]
+    ]
+    genomes_ranked = genomes_ranked[column_order]  # reorder columns
+
+    return genomes_ranked

--- a/micov/cli.py
+++ b/micov/cli.py
@@ -21,6 +21,7 @@ from ._constants import (COLUMN_SAMPLE_ID, COLUMN_GENOME_ID,
                          BED_COV_SAMPLEID_SCHEMA,
                          COLUMN_START, COLUMN_CIGAR, COLUMN_STOP)
 from ._quant import pos_to_bins, make_csv_ready
+from ._rank import rank_genome_of_interest
 
 
 def _first_col_as_set(fp):
@@ -278,6 +279,12 @@ def per_sample_group(parquet_coverage, sample_metadata, sample_metadata_column,
     per_sample_plots(all_coverage, all_covered_positions, metadata_pl,
                      sample_metadata_column, output, monte, monte_iters,
                      target_names)
+
+    outdir = os.path.dirname(output)
+    ranked_genomes = rank_genome_of_interest(outdir)
+    ranked_genomes = pl.DataFrame(ranked_genomes)
+    ranked_genomes.write_csv(
+        f"{outdir}/genome_ranks.tsv", separator="\t")
 
 
 def _load_db(dbbase, sample_metadata, features_to_keep):


### PR DESCRIPTION
Note: This initial commit unfortunately needs a bit of pandas (`conda install pandas`). Will spend more time on converting pandas code to polars in _rank.py but making a quick commit now in case this is blocking other moving parts. 

How to use:
run the normal per-sample-group plots, e.g.
```
micov per-sample-group \
 --parquet-coverage "./example/parquet/example" \
 --sample-metadata "./example/metadata/sample_metadata.txt" \
 --sample-metadata-column "dog" \
 --features-to-keep "./example/metadata/feature_metadata.txt" \
 --output "./example/plots/per_sample_groups/example" \
 --plot
```
and in the output folder look for a tsv called genome_ranks.tsv, which should look like this
```
	filename	group	mean	std	entropy	gini	cv	ranking
1	dog.G001916215.G001916215.dog.position-plot-1_10000th-scale.tsv	No	1.8827646544181977	4.183058576530245	0.9243424908282577	0.4480621660210689	2.221763918668248	1.0
2	dog.G003524985.G003524985.dog.position-plot-1_10000th-scale.tsv	Yes	1.392638036809816	2.3025363975409947	0.6346803814643782	0.27010080808626796	1.6533631400845028	2.0
3	dog.G000378745.G000378745.dog.position-plot-1_10000th-scale.tsv	Yes	9.015510204081632	16.576193292599758	3.612127243379198	0.7112575301761415	1.838630639572139	3.0
4	dog.G000735515.G000735515.dog.position-plot-1_10000th-scale.tsv	No	7.396215257244235	9.121161291216286	3.9249983018906462	0.5910730913219644	1.233220096221855	4.0
5	dog.G001723545.G001723545.dog.position-plot-1_10000th-scale.tsv	No	1.32	0.9569756888948657	0.9239024399278413	0.2182535413304644	0.7249815824961103	5.0
```

Top-ranked genomes technically have a more variable distribution of coverages along the genome in its corresponding sample group.


Key idea: 
For each individual reference genome, rank all sample groups based on entropy, Gini coefficient, and coefficient of variation (CV) of the coverages along the genome.

    Ranking criteria:
    - Entropy: Lower values indicate more variable distributions 
      (ranked in ascending order).
    - Gini coefficient: Higher values indicate more uneven distributions 
      (ranked in descending order).
    - Coefficient of Variation (CV): Higher values indicate greater 
      relative variation (ranked in descending order).

The final ranking is computed using the sum of individual ranks:
- Groups with lower rank sums are considered more variable.
- Ties are handled using the "dense" ranking method, meaning tied values 
  receive the same rank, and the next rank is not skipped.

The metrics of the sample group with the most variable distribution of coverages are then compared with that of other reference genomes. These genomes are then ranked from highest to lowest coverage variability.

