### PR TITLE
Extract position metadata

### DIFF
--- a/micov/_constants.py
+++ b/micov/_constants.py
@@ -22,6 +22,7 @@ COLUMN_COVERED = "covered"
 COLUMN_COVERED_DTYPE = pl.UInt32
 COLUMN_PERCENT_COVERED = "percent_covered"
 COLUMN_PERCENT_COVERED_DTYPE = float
+COLUMN_NAME = "name"
 PRESENT = "present"
 ABSENT = "absent"
 NOT_APPLICABLE = "not applicable"

--- a/micov/_constants.py
+++ b/micov/_constants.py
@@ -22,6 +22,10 @@ COLUMN_COVERED = "covered"
 COLUMN_COVERED_DTYPE = pl.UInt32
 COLUMN_PERCENT_COVERED = "percent_covered"
 COLUMN_PERCENT_COVERED_DTYPE = float
+PRESENT = "present"
+ABSENT = "absent"
+NOT_APPLICABLE = "not applicable"
+COLUMN_REGION_ID = "region_id"
 
 ### should really probably just use a dataclass, and type annotations?
 

--- a/micov/_view.py
+++ b/micov/_view.py
@@ -337,9 +337,10 @@ class View:
                 FROM unconstrained_positions pos
                     LEFT JOIN feature_metadata fm
                         ON pos.{COLUMN_GENOME_ID}=fm.{COLUMN_GENOME_ID}
-                ORDER BY pos.{COLUMN_SAMPLE_ID}, pos.{COLUMN_GENOME_ID}
             );
+        """)
 
+        self.con.sql(f"""
             -- extract the samples which are "present" and "absent" and the
             -- regions they are present -- in. Note that a sample is present in a
             -- region if it has coverage in that -- region. It is considered absent

--- a/micov/_view.py
+++ b/micov/_view.py
@@ -267,3 +267,12 @@ class View:
             sql = "SELECT DISTINCT genome_id FROM coverage"
             target_names = {k[0]: k[0] for k in self.con.sql(sql).fetchall()}
         return target_names
+
+    def sample_presence_absence(self):
+        if not self.constrain_positions:
+            raise ValueError("Cannot calculate presence/absence without positions.")
+
+        # self.con.sql(f"""
+        #    SELECT {COLUMN_SAMPLE_ID},
+        #
+        #   """)

--- a/micov/_view.py
+++ b/micov/_view.py
@@ -223,6 +223,20 @@ class View:
                                      JOIN genome_lengths gl
                                          ON fc.{COLUMN_GENOME_ID}=gl.{COLUMN_GENOME_ID}
                     """)
+        self._integrity_checks()
+
+    def _integrity_checks(self):
+        region_id_uniqueness = self.con.sql(f"""
+            SELECT
+                CASE
+                    WHEN COUNT(DISTINCT {COLUMN_REGION_ID}) == COUNT({COLUMN_REGION_ID})
+                    THEN 'OK'
+                    ELSE 'FAIL'
+                END AS region_id_uniqueness
+            FROM feature_metadata
+        """).fetchone()[0]
+        if region_id_uniqueness == "FAIL":
+            raise ValueError("Region IDs are not unique.")
 
     def metadata(self):
         return self.con.sql("SELECT * FROM metadata")

--- a/micov/_view.py
+++ b/micov/_view.py
@@ -302,15 +302,17 @@ class View:
     def feature_names(self):
         if self.feature_names_df is None:
             return self.con.sql(f"""
-                SELECT DISTINCT {COLUMN_GENOME_ID}, {COLUMN_GENOME_ID}
+                SELECT DISTINCT {COLUMN_GENOME_ID}, {COLUMN_GENOME_ID} AS {COLUMN_NAME}
                 FROM feature_metadata
             """)
         else:
             feature_names = self.feature_names_df  # noqa
             return self.con.sql(f"""
-                SELECT DISTINCT fm.{COLUMN_GENOME_ID}, fn.{COLUMN_NAME}
-                FROM feature_names fn
-                JOIN feature_metadata fm
+                SELECT DISTINCT
+                    fm.{COLUMN_GENOME_ID},
+                    COALESCE(fn.{COLUMN_NAME}, fm.{COLUMN_GENOME_ID}) AS {COLUMN_NAME}
+                FROM feature_metadata fm
+                LEFT JOIN feature_names fn
                     USING ({COLUMN_GENOME_ID})""")
 
     def sample_presence_absence(self):

--- a/micov/cli.py
+++ b/micov/cli.py
@@ -584,7 +584,7 @@ def extract_sample_presence(
     """Extract variables for each described feature to keep region."""
     metadata_pl = parse_sample_metadata(sample_metadata)
     features_pl = parse_features_to_keep(features_to_keep)
-    view = View(parquet_coverage, metadata_pl, features_pl)
+    view = View(parquet_coverage, metadata_pl, features_pl, threads, memory)
 
     view.sample_presence_absence().pl().write_csv(
         output, separator="\t", include_header=True

--- a/micov/cli.py
+++ b/micov/cli.py
@@ -578,5 +578,50 @@ def binning(
     )
 
 
+@cli.command()
+@click.option(
+    "--parquet-coverage",
+    type=click.Path(exists=False),
+    required=True,
+    help=(
+        "Pre-computed coverage data as parquet. "
+        "This should be the basename used, i.e. "
+        'for "foo.coverage.parquet", please use '
+        '"foo"'
+    ),
+)
+@click.option(
+    "--sample-metadata",
+    type=click.Path(exists=True),
+    required=True,
+    help="A metadata file with the sample metadata",
+)
+@click.option(
+    "--features-to-keep",
+    type=click.Path(exists=True),
+    required=False,
+    help="A metadata file with the features to keep",
+)
+@click.option("--output", type=click.Path(exists=False), required=True)
+@click.option("--memory", type=str, default="16gb", required=False)
+@click.option("--threads", type=int, default=4, required=False)
+def extract_sample_presence(
+    parquet_coverage,
+    sample_metadata,
+    features_to_keep,
+    output,
+    memory,
+    threads,
+):
+    """Extract variables for each described feature to keep region."""
+    metadata_pl = parse_sample_metadata(sample_metadata)
+    features_pl = parse_features_to_keep(features_to_keep)
+    view = View(parquet_coverage, metadata_pl, features_pl)
+
+    view.sample_presence_absence().pl().write_csv(
+        output, separator="\t", include_header=True
+    )
+
+
 if __name__ == "__main__":
     cli()

--- a/micov/tests/test_io.py
+++ b/micov/tests/test_io.py
@@ -12,6 +12,7 @@ from micov._constants import (
     BED_COV_SCHEMA,
     COLUMN_GENOME_ID,
     COLUMN_LENGTH,
+    COLUMN_NAME,
     COLUMN_START,
     COLUMN_TAXONOMY,
     GENOME_COVERAGE_SCHEMA,
@@ -20,6 +21,7 @@ from micov._constants import (
 )
 from micov._io import (
     compress_from_stream,
+    parse_feature_names,
     parse_genome_lengths,
     parse_qiita_coverages,
     parse_sam_to_df,
@@ -378,6 +380,23 @@ class IOTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "Lengths of zero or less"):
             parse_genome_lengths(self.name)
+
+    def test_parse_feature_names(self):
+        data = (
+            "some_id\tsomecolumn\tanothercolumn\n"
+            "abc\tthings and stuff\temtpy\n"
+            "x\tfoo; bar; baz thing\tdsf\n"
+        )
+        with open(self.name, "w") as fp:
+            fp.write(data)
+
+        exp = pl.DataFrame(
+            [["abc", "things_and_stuff"], ["x", "baz_thing"]],
+            orient="row",
+            schema=[COLUMN_GENOME_ID, COLUMN_NAME],
+        )
+        obs = parse_feature_names(self.name)
+        plt.assert_frame_equal(obs, exp)
 
     def test_parse_taxonomy_good(self):
         data = (

--- a/micov/tests/test_view.py
+++ b/micov/tests/test_view.py
@@ -439,6 +439,52 @@ class ViewTests(unittest.TestCase):
             obs_fmd, exp_fmd, check_column_order=False, check_row_order=False
         )
 
+    def test_sample_presence_absence_no_regions(self):
+        v = View(f"{self.d}/{self.name}", self.md, self.feat)
+        with self.assertRaisesRegex(ValueError, "No region constraints"):
+            v.sample_presence_absence()
+
+    def test_sample_presence_absence_single_region(self):
+        feat = pl.DataFrame(
+            [
+                ["G1", 0, 100],
+                ["G2", 40, 60],
+                ["G3", 40, 60],
+                ["G4", 90, 100],
+                ["G5", 40, 60],
+            ],
+            orient="row",
+            schema=[
+                (COLUMN_GENOME_ID, str),
+                (COLUMN_START, COLUMN_START_DTYPE),
+                (COLUMN_STOP, COLUMN_STOP_DTYPE),
+            ],
+        )
+        v = View(f"{self.d}/{self.name}", self.md, feat)
+
+        PRESENT = 'present'
+        ABSENT = 'absent'
+
+        obs = v.sample_presence_absence().pl()
+        exp = pl.DataFrame(
+            [['S1', PRESENT, PRESENT, ABSENT, ABSENT, ABSENT],
+             ['S2', ABSENT, ABSENT, ABSENT, ABSENT, ABSENT],
+             ['S3', ABSENT, PRESENT, PRESENT, ABSENT, PRESENT],
+            orient="row",
+            schema=[
+                (COLUMN_SAMPLE_ID, str),
+                ("micov_G1_0_100", str),
+                ("micov_G2_40_60", str),
+                ("micov_G3_40_60", str),
+                ("micov_G4_90_100", str),
+                ("micov_G5_40_60", str),
+            ],
+        )
+
+        plt.assert_frame_equal(
+            obs, exp, check_column_order=False, check_row_order=False
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/micov/tests/test_view.py
+++ b/micov/tests/test_view.py
@@ -492,10 +492,29 @@ class ViewTests(unittest.TestCase):
                 ("G5_40_60", str),
             ],
         )
-        print(obs)
         plt.assert_frame_equal(
             obs, exp, check_column_order=False, check_row_order=False
         )
+
+    def test_integrity_checks(self):
+        feat = pl.DataFrame(
+            [
+                ["G1", 0, 100],
+                ["G2", 40, 60],
+                ["G3", 40, 60],
+                ["G3", 40, 60],
+                ["G4", 90, 100],
+                ["G5", 40, 60],
+            ],
+            orient="row",
+            schema=[
+                (COLUMN_GENOME_ID, str),
+                (COLUMN_START, COLUMN_START_DTYPE),
+                (COLUMN_STOP, COLUMN_STOP_DTYPE),
+            ],
+        )
+        with self.assertRaisesRegex(ValueError, "Region IDs are not unique"):
+            View(f"{self.d}/{self.name}", self.md, feat)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR allows for extracting sample presence/absence/not applicable by genomes and coordinates.

A sample is present if there is coverage in a described region. It is absent if it lacks coverage in the described region BUT has nonzero coverage to the genome. It is not applicable if the sample lacks coverage in the region AND has zero coverage to the genome.

With `View` it is now possible to describe multiple regions for a genome. However, that has not bubbled out to plotting yet. Those commits are coming in a moment. 